### PR TITLE
Removal of master/slave words

### DIFF
--- a/google-cloud-sdk/.install/.backup/lib/googlecloudapis/apitools/base/py/batch.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudapis/apitools/base/py/batch.py
@@ -147,7 +147,7 @@ class BatchApiRequest(object):
         method_config, request, global_params=global_params,
         upload_config=upload_config)
 
-    # Create the request and add it to our master list.
+    # Create the request and add it to our main list.
     api_request = self.ApiCall(
         http_request, self.retryable_codes, service, method_config)
     self.api_requests.append(api_request)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudapis/compute/alpha/compute_alpha_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudapis/compute/alpha/compute_alpha_messages.py
@@ -283,10 +283,10 @@ class AttachedDisk(messages.Message):
       disk, in the form persistent-disks-x, where x is a number assigned by
       Google Compute Engine. This field is only applicable for persistent
       disks.
-    diskMasterKey: Master key of the disk; required only if the disk already
-      exists and is master key protected. If the disk is being created and a
-      master key is provided, the newly created disk will be protected with
-      this master key. Format: Random 256-bit key material encoded in base64.
+    diskMainKey: Main key of the disk; required only if the disk already
+      exists and is main key protected. If the disk is being created and a
+      main key is provided, the newly created disk will be protected with
+      this main key. Format: Random 256-bit key material encoded in base64.
     index: Assigns a zero-based index to this disk, where 0 is reserved for
       the boot disk. For example, if you have many disks attached to an
       instance, each disk would have a unique index number. If not specified,
@@ -344,7 +344,7 @@ class AttachedDisk(messages.Message):
   autoDelete = messages.BooleanField(1)
   boot = messages.BooleanField(2)
   deviceName = messages.StringField(3)
-  diskMasterKey = messages.StringField(4)
+  diskMainKey = messages.StringField(4)
   index = messages.IntegerField(5, variant=messages.Variant.INT32)
   initializeParams = messages.MessageField('AttachedDiskInitializeParams', 6)
   interface = messages.EnumField('InterfaceValueValuesEnum', 7)
@@ -393,8 +393,8 @@ class AttachedDiskInitializeParams(messages.Message):
       to include the project in the URL:  projects/debian-
       cloud/global/images/debian-7-wheezy-vYYYYMMDD   where vYYYYMMDD is the
       image version. The fully-qualified URL will also work in both cases.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
   """
 
@@ -416,7 +416,7 @@ class AttachedDiskInitializeParams(messages.Message):
   diskStorageType = messages.EnumField('DiskStorageTypeValueValuesEnum', 3)
   diskType = messages.StringField(4)
   sourceImage = messages.StringField(5)
-  sourceImageMasterKey = messages.StringField(6)
+  sourceImageMainKey = messages.StringField(6)
 
 
 class Backend(messages.Message):
@@ -3030,9 +3030,9 @@ class Disk(messages.Message):
       only).
     description: An optional textual description of the resource; provided by
       the client when the resource is created.
-    diskMasterKey: Master key to protect the disk. When attempting to use a
-      master key protected disk, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    diskMainKey: Main key to protect the disk. When attempting to use a
+      main key protected disk, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     id: Unique identifier for the resource; defined by the server (output
       only).
@@ -3049,15 +3049,15 @@ class Disk(messages.Message):
     sourceImageId: The 'id' value of the image used to create this disk. This
       value may be used to determine whether the disk was created from the
       current or a previous instance of a given image.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
     sourceSnapshot: The source snapshot used to create this disk.
     sourceSnapshotId: The 'id' value of the snapshot used to create this disk.
       This value may be used to determine whether the disk was created from
       the current or a previous instance of a given disk snapshot.
-    sourceSnapshotMasterKey: Master key of the source snapshot; required only
-      if the source snapshot is master key protected. Format: Random 256-bit
+    sourceSnapshotMainKey: Main key of the source snapshot; required only
+      if the source snapshot is main key protected. Format: Random 256-bit
       key material encoded in base64.
     status: The status of disk creation (output only).
     storageType: DEPRECATED. Storage type of the persistent disk.
@@ -3092,7 +3092,7 @@ class Disk(messages.Message):
 
   creationTimestamp = messages.StringField(1)
   description = messages.StringField(2)
-  diskMasterKey = messages.StringField(3)
+  diskMainKey = messages.StringField(3)
   id = messages.IntegerField(4, variant=messages.Variant.UINT64)
   kind = messages.StringField(5, default=u'compute#disk')
   licenses = messages.StringField(6, repeated=True)
@@ -3102,10 +3102,10 @@ class Disk(messages.Message):
   sizeGb = messages.IntegerField(10)
   sourceImage = messages.StringField(11)
   sourceImageId = messages.StringField(12)
-  sourceImageMasterKey = messages.StringField(13)
+  sourceImageMainKey = messages.StringField(13)
   sourceSnapshot = messages.StringField(14)
   sourceSnapshotId = messages.StringField(15)
-  sourceSnapshotMasterKey = messages.StringField(16)
+  sourceSnapshotMainKey = messages.StringField(16)
   status = messages.EnumField('StatusValueValuesEnum', 17)
   storageType = messages.EnumField('StorageTypeValueValuesEnum', 18)
   type = messages.StringField(19)
@@ -3963,9 +3963,9 @@ class Image(messages.Message):
     diskSizeGb: Size of the image when restored onto a disk (in GiB).
     id: Unique identifier for the resource; defined by the server (output
       only).
-    imageMasterKey: Master key to protect the image. When attempting to use a
-      master key protected image, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    imageMainKey: Main key to protect the image. When attempting to use a
+      main key protected image, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     kind: Type of the resource.
     licenses: Public visible licenses.
@@ -3977,8 +3977,8 @@ class Image(messages.Message):
     sourceDiskId: The 'id' value of the disk used to create this image. This
       value may be used to determine whether the image was taken from the
       current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     sourceType: Must be "RAW"; provided by the client when the disk image is
       created.
@@ -4055,7 +4055,7 @@ class Image(messages.Message):
   description = messages.StringField(4)
   diskSizeGb = messages.IntegerField(5)
   id = messages.IntegerField(6, variant=messages.Variant.UINT64)
-  imageMasterKey = messages.StringField(7)
+  imageMainKey = messages.StringField(7)
   kind = messages.StringField(8, default=u'compute#image')
   licenses = messages.StringField(9, repeated=True)
   name = messages.StringField(10)
@@ -4063,7 +4063,7 @@ class Image(messages.Message):
   selfLink = messages.StringField(12)
   sourceDisk = messages.StringField(13)
   sourceDiskId = messages.StringField(14)
-  sourceDiskMasterKey = messages.StringField(15)
+  sourceDiskMainKey = messages.StringField(15)
   sourceType = messages.EnumField('SourceTypeValueValuesEnum', 16, default=u'RAW')
   status = messages.EnumField('StatusValueValuesEnum', 17)
 
@@ -5541,16 +5541,16 @@ class Snapshot(messages.Message):
     name: Name of the resource; provided by the client when the resource is
       created. The name must be 1-63 characters long, and comply with RFC1035.
     selfLink: Server defined URL for the resource (output only).
-    snapshotMasterKey: Master key to protect the snapshot. When attempting to
-      use a master key protected snapshot, the key must be provided otherwise
-      the request will fail. Master keys do not protect resource metadata.
+    snapshotMainKey: Main key to protect the snapshot. When attempting to
+      use a main key protected snapshot, the key must be provided otherwise
+      the request will fail. Main keys do not protect resource metadata.
       Format: Random 256-bit key material encoded in base64.
     sourceDisk: The source disk used to create this snapshot.
     sourceDiskId: The 'id' value of the disk used to create this snapshot.
       This value may be used to determine whether the snapshot was taken from
       the current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     status: The status of the persistent disk snapshot (output only).
     storageBytes: A size of the the storage used by the snapshot. As snapshots
@@ -5596,10 +5596,10 @@ class Snapshot(messages.Message):
   licenses = messages.StringField(6, repeated=True)
   name = messages.StringField(7)
   selfLink = messages.StringField(8)
-  snapshotMasterKey = messages.StringField(9)
+  snapshotMainKey = messages.StringField(9)
   sourceDisk = messages.StringField(10)
   sourceDiskId = messages.StringField(11)
-  sourceDiskMasterKey = messages.StringField(12)
+  sourceDiskMainKey = messages.StringField(12)
   status = messages.EnumField('StatusValueValuesEnum', 13)
   storageBytes = messages.IntegerField(14)
   storageBytesStatus = messages.EnumField('StorageBytesStatusValueValuesEnum', 15)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudapis/compute/beta/compute_beta_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudapis/compute/beta/compute_beta_messages.py
@@ -283,10 +283,10 @@ class AttachedDisk(messages.Message):
       disk, in the form persistent-disks-x, where x is a number assigned by
       Google Compute Engine. This field is only applicable for persistent
       disks.
-    diskMasterKey: Master key of the disk; required only if the disk already
-      exists and is master key protected. If the disk is being created and a
-      master key is provided, the newly created disk will be protected with
-      this master key. Format: Random 256-bit key material encoded in base64.
+    diskMainKey: Main key of the disk; required only if the disk already
+      exists and is main key protected. If the disk is being created and a
+      main key is provided, the newly created disk will be protected with
+      this main key. Format: Random 256-bit key material encoded in base64.
     index: Assigns a zero-based index to this disk, where 0 is reserved for
       the boot disk. For example, if you have many disks attached to an
       instance, each disk would have a unique index number. If not specified,
@@ -344,7 +344,7 @@ class AttachedDisk(messages.Message):
   autoDelete = messages.BooleanField(1)
   boot = messages.BooleanField(2)
   deviceName = messages.StringField(3)
-  diskMasterKey = messages.StringField(4)
+  diskMainKey = messages.StringField(4)
   index = messages.IntegerField(5, variant=messages.Variant.INT32)
   initializeParams = messages.MessageField('AttachedDiskInitializeParams', 6)
   interface = messages.EnumField('InterfaceValueValuesEnum', 7)
@@ -393,8 +393,8 @@ class AttachedDiskInitializeParams(messages.Message):
       to include the project in the URL:  projects/debian-
       cloud/global/images/debian-7-wheezy-vYYYYMMDD   where vYYYYMMDD is the
       image version. The fully-qualified URL will also work in both cases.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
   """
 
@@ -416,7 +416,7 @@ class AttachedDiskInitializeParams(messages.Message):
   diskStorageType = messages.EnumField('DiskStorageTypeValueValuesEnum', 3)
   diskType = messages.StringField(4)
   sourceImage = messages.StringField(5)
-  sourceImageMasterKey = messages.StringField(6)
+  sourceImageMainKey = messages.StringField(6)
 
 
 class Backend(messages.Message):
@@ -3030,9 +3030,9 @@ class Disk(messages.Message):
       only).
     description: An optional textual description of the resource; provided by
       the client when the resource is created.
-    diskMasterKey: Master key to protect the disk. When attempting to use a
-      master key protected disk, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    diskMainKey: Main key to protect the disk. When attempting to use a
+      main key protected disk, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     id: Unique identifier for the resource; defined by the server (output
       only).
@@ -3049,15 +3049,15 @@ class Disk(messages.Message):
     sourceImageId: The 'id' value of the image used to create this disk. This
       value may be used to determine whether the disk was created from the
       current or a previous instance of a given image.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
     sourceSnapshot: The source snapshot used to create this disk.
     sourceSnapshotId: The 'id' value of the snapshot used to create this disk.
       This value may be used to determine whether the disk was created from
       the current or a previous instance of a given disk snapshot.
-    sourceSnapshotMasterKey: Master key of the source snapshot; required only
-      if the source snapshot is master key protected. Format: Random 256-bit
+    sourceSnapshotMainKey: Main key of the source snapshot; required only
+      if the source snapshot is main key protected. Format: Random 256-bit
       key material encoded in base64.
     status: The status of disk creation (output only).
     storageType: DEPRECATED. Storage type of the persistent disk.
@@ -3092,7 +3092,7 @@ class Disk(messages.Message):
 
   creationTimestamp = messages.StringField(1)
   description = messages.StringField(2)
-  diskMasterKey = messages.StringField(3)
+  diskMainKey = messages.StringField(3)
   id = messages.IntegerField(4, variant=messages.Variant.UINT64)
   kind = messages.StringField(5, default=u'compute#disk')
   licenses = messages.StringField(6, repeated=True)
@@ -3102,10 +3102,10 @@ class Disk(messages.Message):
   sizeGb = messages.IntegerField(10)
   sourceImage = messages.StringField(11)
   sourceImageId = messages.StringField(12)
-  sourceImageMasterKey = messages.StringField(13)
+  sourceImageMainKey = messages.StringField(13)
   sourceSnapshot = messages.StringField(14)
   sourceSnapshotId = messages.StringField(15)
-  sourceSnapshotMasterKey = messages.StringField(16)
+  sourceSnapshotMainKey = messages.StringField(16)
   status = messages.EnumField('StatusValueValuesEnum', 17)
   storageType = messages.EnumField('StorageTypeValueValuesEnum', 18)
   type = messages.StringField(19)
@@ -3963,9 +3963,9 @@ class Image(messages.Message):
     diskSizeGb: Size of the image when restored onto a disk (in GiB).
     id: Unique identifier for the resource; defined by the server (output
       only).
-    imageMasterKey: Master key to protect the image. When attempting to use a
-      master key protected image, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    imageMainKey: Main key to protect the image. When attempting to use a
+      main key protected image, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     kind: Type of the resource.
     licenses: Public visible licenses.
@@ -3977,8 +3977,8 @@ class Image(messages.Message):
     sourceDiskId: The 'id' value of the disk used to create this image. This
       value may be used to determine whether the image was taken from the
       current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     sourceType: Must be "RAW"; provided by the client when the disk image is
       created.
@@ -4055,7 +4055,7 @@ class Image(messages.Message):
   description = messages.StringField(4)
   diskSizeGb = messages.IntegerField(5)
   id = messages.IntegerField(6, variant=messages.Variant.UINT64)
-  imageMasterKey = messages.StringField(7)
+  imageMainKey = messages.StringField(7)
   kind = messages.StringField(8, default=u'compute#image')
   licenses = messages.StringField(9, repeated=True)
   name = messages.StringField(10)
@@ -4063,7 +4063,7 @@ class Image(messages.Message):
   selfLink = messages.StringField(12)
   sourceDisk = messages.StringField(13)
   sourceDiskId = messages.StringField(14)
-  sourceDiskMasterKey = messages.StringField(15)
+  sourceDiskMainKey = messages.StringField(15)
   sourceType = messages.EnumField('SourceTypeValueValuesEnum', 16, default=u'RAW')
   status = messages.EnumField('StatusValueValuesEnum', 17)
 
@@ -5541,16 +5541,16 @@ class Snapshot(messages.Message):
     name: Name of the resource; provided by the client when the resource is
       created. The name must be 1-63 characters long, and comply with RFC1035.
     selfLink: Server defined URL for the resource (output only).
-    snapshotMasterKey: Master key to protect the snapshot. When attempting to
-      use a master key protected snapshot, the key must be provided otherwise
-      the request will fail. Master keys do not protect resource metadata.
+    snapshotMainKey: Main key to protect the snapshot. When attempting to
+      use a main key protected snapshot, the key must be provided otherwise
+      the request will fail. Main keys do not protect resource metadata.
       Format: Random 256-bit key material encoded in base64.
     sourceDisk: The source disk used to create this snapshot.
     sourceDiskId: The 'id' value of the disk used to create this snapshot.
       This value may be used to determine whether the snapshot was taken from
       the current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     status: The status of the persistent disk snapshot (output only).
     storageBytes: A size of the the storage used by the snapshot. As snapshots
@@ -5596,10 +5596,10 @@ class Snapshot(messages.Message):
   licenses = messages.StringField(6, repeated=True)
   name = messages.StringField(7)
   selfLink = messages.StringField(8)
-  snapshotMasterKey = messages.StringField(9)
+  snapshotMainKey = messages.StringField(9)
   sourceDisk = messages.StringField(10)
   sourceDiskId = messages.StringField(11)
-  sourceDiskMasterKey = messages.StringField(12)
+  sourceDiskMainKey = messages.StringField(12)
   status = messages.EnumField('StatusValueValuesEnum', 13)
   storageBytes = messages.IntegerField(14)
   storageBytesStatus = messages.EnumField('StorageBytesStatusValueValuesEnum', 15)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
@@ -178,11 +178,11 @@ class ContainerV1beta1(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes master instance.
+      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes main instance.
 
 The cluster is created in the project's default network.
 
-A firewall is added that allows traffic into port 443 on the master, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
+A firewall is added that allows traffic into port 443 on the main, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
 
 Finally, a route named k8s-iproute-10-xx-0-0 is created to track that the cluster's 10.xx.0.0/16 CIDR has been assigned.
 
@@ -197,7 +197,7 @@ Finally, a route named k8s-iproute-10-xx-0-0 is created to track that the cluste
           config, request, global_params=global_params)
 
     def Delete(self, request, global_params=None):
-      """Deletes the cluster, including the Kubernetes master and all worker nodes.
+      """Deletes the cluster, including the Kubernetes main and all worker nodes.
 
 Firewalls and routes that were configured at cluster creation are also deleted.
 

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
@@ -18,7 +18,7 @@ class Cluster(messages.Message):
     StatusValueValuesEnum: [Output only] The current status of this cluster.
 
   Fields:
-    clusterApiVersion: The API version of the Kubernetes master and kubelets
+    clusterApiVersion: The API version of the Kubernetes main and kubelets
       running in this cluster. Leave blank to pick up the latest stable
       release, or specify a version of the form "x.y.z". The Google Container
       Engine release notes lists the currently supported versions. If an
@@ -30,11 +30,11 @@ class Cluster(messages.Message):
       RFC3339 text format.
     description: An optional description of this cluster.
     endpoint: [Output only] The IP address of this cluster's Kubernetes
-      master. The endpoint can be accessed from the internet at
-      https://username:password@endpoint/.  See the masterAuth property of
+      main. The endpoint can be accessed from the internet at
+      https://username:password@endpoint/.  See the mainAuth property of
       this resource for username and password information.
-    masterAuth: The HTTP basic authentication information for accessing the
-      master. Because the master endpoint is open to the internet, you should
+    mainAuth: The HTTP basic authentication information for accessing the
+      main. Because the main endpoint is open to the internet, you should
       create a strong password.
     name: The name of this cluster. The name must be unique within this
       project and zone, and can be up to 40 characters with the following
@@ -48,7 +48,7 @@ class Cluster(messages.Message):
       node for hosting containers.
     numNodes: The number of nodes to create in this cluster. You must ensure
       that your Compute Engine resource quota is sufficient for this number of
-      instances plus one (to include the master). You must also have available
+      instances plus one (to include the main). You must also have available
       firewall and routes quota.
     selfLink: [Output only] Server-defined URL for the resource.
     servicesIpv4Cidr: [Output only] The IP addresses of the Kubernetes
@@ -80,7 +80,7 @@ class Cluster(messages.Message):
   creationTimestamp = messages.StringField(3)
   description = messages.StringField(4)
   endpoint = messages.StringField(5)
-  masterAuth = messages.MessageField('MasterAuth', 6)
+  mainAuth = messages.MessageField('MainAuth', 6)
   name = messages.StringField(7)
   network = messages.StringField(8)
   nodeConfig = messages.MessageField('NodeConfig', 9)
@@ -251,13 +251,13 @@ class ListOperationsResponse(messages.Message):
   operations = messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(messages.Message):
-  """A MasterAuth object.
+class MainAuth(messages.Message):
+  """A MainAuth object.
 
   Fields:
-    password: The password to use when accessing the Kubernetes master
+    password: The password to use when accessing the Kubernetes main
       endpoint.
-    user: The username to use when accessing the Kubernetes master endpoint.
+    user: The username to use when accessing the Kubernetes main endpoint.
   """
 
   password = messages.StringField(1)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
@@ -160,7 +160,7 @@ class DatabaseInstance(messages.Message):
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     project: The project ID of the project containing the Cloud SQL instance.
@@ -189,7 +189,7 @@ class DatabaseInstance(messages.Message):
   ipAddresses = messages.MessageField('IpMapping', 6, repeated=True)
   ipv6Address = messages.StringField(7)
   kind = messages.StringField(8, default=u'sql#instance')
-  masterInstanceName = messages.StringField(9)
+  mainInstanceName = messages.StringField(9)
   maxDiskSize = messages.IntegerField(10)
   project = messages.StringField(11)
   region = messages.StringField(12)

--- a/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/gcloud/sdktools/root/init.py
+++ b/google-cloud-sdk/.install/.backup/lib/googlecloudsdk/gcloud/sdktools/root/init.py
@@ -47,7 +47,7 @@ class Init(base.Command):
           git repository associated with PROJECT. This repository will
           automatically be connected to Google, and it will use the credentials
           indicated as _active_ by `gcloud auth list`. Pushing
-          to the origin's _master_ branch will trigger an App Engine deployment
+          to the origin's _main_ branch will trigger an App Engine deployment
           using the contents of that branch.
       """.format(dotgcloud=config.Paths.CLOUDSDK_WORKSPACE_CONFIG_DIR_NAME),
       'EXAMPLES': textwrap.dedent("""\
@@ -60,7 +60,7 @@ class Init(base.Command):
             $ cd MYPROJECT/default
             $ git pull
               https://github.com/GoogleCloudPlatform/appengine-helloworld-python
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/google-cloud-sdk/.install/.backup/lib/jinja2/pkg_resources.py
+++ b/google-cloud-sdk/.install/.backup/lib/jinja2/pkg_resources.py
@@ -2693,7 +2693,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 
 try:

--- a/google-cloud-sdk/lib/googlecloudapis/apitools/base/py/batch.py
+++ b/google-cloud-sdk/lib/googlecloudapis/apitools/base/py/batch.py
@@ -147,7 +147,7 @@ class BatchApiRequest(object):
         method_config, request, global_params=global_params,
         upload_config=upload_config)
 
-    # Create the request and add it to our master list.
+    # Create the request and add it to our main list.
     api_request = self.ApiCall(
         http_request, self.retryable_codes, service, method_config)
     self.api_requests.append(api_request)

--- a/google-cloud-sdk/lib/googlecloudapis/compute/alpha/compute_alpha_messages.py
+++ b/google-cloud-sdk/lib/googlecloudapis/compute/alpha/compute_alpha_messages.py
@@ -283,10 +283,10 @@ class AttachedDisk(messages.Message):
       disk, in the form persistent-disks-x, where x is a number assigned by
       Google Compute Engine. This field is only applicable for persistent
       disks.
-    diskMasterKey: Master key of the disk; required only if the disk already
-      exists and is master key protected. If the disk is being created and a
-      master key is provided, the newly created disk will be protected with
-      this master key. Format: Random 256-bit key material encoded in base64.
+    diskMainKey: Main key of the disk; required only if the disk already
+      exists and is main key protected. If the disk is being created and a
+      main key is provided, the newly created disk will be protected with
+      this main key. Format: Random 256-bit key material encoded in base64.
     index: Assigns a zero-based index to this disk, where 0 is reserved for
       the boot disk. For example, if you have many disks attached to an
       instance, each disk would have a unique index number. If not specified,
@@ -344,7 +344,7 @@ class AttachedDisk(messages.Message):
   autoDelete = messages.BooleanField(1)
   boot = messages.BooleanField(2)
   deviceName = messages.StringField(3)
-  diskMasterKey = messages.StringField(4)
+  diskMainKey = messages.StringField(4)
   index = messages.IntegerField(5, variant=messages.Variant.INT32)
   initializeParams = messages.MessageField('AttachedDiskInitializeParams', 6)
   interface = messages.EnumField('InterfaceValueValuesEnum', 7)
@@ -393,8 +393,8 @@ class AttachedDiskInitializeParams(messages.Message):
       to include the project in the URL:  projects/debian-
       cloud/global/images/debian-7-wheezy-vYYYYMMDD   where vYYYYMMDD is the
       image version. The fully-qualified URL will also work in both cases.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
   """
 
@@ -416,7 +416,7 @@ class AttachedDiskInitializeParams(messages.Message):
   diskStorageType = messages.EnumField('DiskStorageTypeValueValuesEnum', 3)
   diskType = messages.StringField(4)
   sourceImage = messages.StringField(5)
-  sourceImageMasterKey = messages.StringField(6)
+  sourceImageMainKey = messages.StringField(6)
 
 
 class Backend(messages.Message):
@@ -3030,9 +3030,9 @@ class Disk(messages.Message):
       only).
     description: An optional textual description of the resource; provided by
       the client when the resource is created.
-    diskMasterKey: Master key to protect the disk. When attempting to use a
-      master key protected disk, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    diskMainKey: Main key to protect the disk. When attempting to use a
+      main key protected disk, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     id: Unique identifier for the resource; defined by the server (output
       only).
@@ -3049,15 +3049,15 @@ class Disk(messages.Message):
     sourceImageId: The 'id' value of the image used to create this disk. This
       value may be used to determine whether the disk was created from the
       current or a previous instance of a given image.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
     sourceSnapshot: The source snapshot used to create this disk.
     sourceSnapshotId: The 'id' value of the snapshot used to create this disk.
       This value may be used to determine whether the disk was created from
       the current or a previous instance of a given disk snapshot.
-    sourceSnapshotMasterKey: Master key of the source snapshot; required only
-      if the source snapshot is master key protected. Format: Random 256-bit
+    sourceSnapshotMainKey: Main key of the source snapshot; required only
+      if the source snapshot is main key protected. Format: Random 256-bit
       key material encoded in base64.
     status: The status of disk creation (output only).
     storageType: DEPRECATED. Storage type of the persistent disk.
@@ -3092,7 +3092,7 @@ class Disk(messages.Message):
 
   creationTimestamp = messages.StringField(1)
   description = messages.StringField(2)
-  diskMasterKey = messages.StringField(3)
+  diskMainKey = messages.StringField(3)
   id = messages.IntegerField(4, variant=messages.Variant.UINT64)
   kind = messages.StringField(5, default=u'compute#disk')
   licenses = messages.StringField(6, repeated=True)
@@ -3102,10 +3102,10 @@ class Disk(messages.Message):
   sizeGb = messages.IntegerField(10)
   sourceImage = messages.StringField(11)
   sourceImageId = messages.StringField(12)
-  sourceImageMasterKey = messages.StringField(13)
+  sourceImageMainKey = messages.StringField(13)
   sourceSnapshot = messages.StringField(14)
   sourceSnapshotId = messages.StringField(15)
-  sourceSnapshotMasterKey = messages.StringField(16)
+  sourceSnapshotMainKey = messages.StringField(16)
   status = messages.EnumField('StatusValueValuesEnum', 17)
   storageType = messages.EnumField('StorageTypeValueValuesEnum', 18)
   type = messages.StringField(19)
@@ -3963,9 +3963,9 @@ class Image(messages.Message):
     diskSizeGb: Size of the image when restored onto a disk (in GiB).
     id: Unique identifier for the resource; defined by the server (output
       only).
-    imageMasterKey: Master key to protect the image. When attempting to use a
-      master key protected image, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    imageMainKey: Main key to protect the image. When attempting to use a
+      main key protected image, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     kind: Type of the resource.
     licenses: Public visible licenses.
@@ -3977,8 +3977,8 @@ class Image(messages.Message):
     sourceDiskId: The 'id' value of the disk used to create this image. This
       value may be used to determine whether the image was taken from the
       current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     sourceType: Must be "RAW"; provided by the client when the disk image is
       created.
@@ -4055,7 +4055,7 @@ class Image(messages.Message):
   description = messages.StringField(4)
   diskSizeGb = messages.IntegerField(5)
   id = messages.IntegerField(6, variant=messages.Variant.UINT64)
-  imageMasterKey = messages.StringField(7)
+  imageMainKey = messages.StringField(7)
   kind = messages.StringField(8, default=u'compute#image')
   licenses = messages.StringField(9, repeated=True)
   name = messages.StringField(10)
@@ -4063,7 +4063,7 @@ class Image(messages.Message):
   selfLink = messages.StringField(12)
   sourceDisk = messages.StringField(13)
   sourceDiskId = messages.StringField(14)
-  sourceDiskMasterKey = messages.StringField(15)
+  sourceDiskMainKey = messages.StringField(15)
   sourceType = messages.EnumField('SourceTypeValueValuesEnum', 16, default=u'RAW')
   status = messages.EnumField('StatusValueValuesEnum', 17)
 
@@ -5541,16 +5541,16 @@ class Snapshot(messages.Message):
     name: Name of the resource; provided by the client when the resource is
       created. The name must be 1-63 characters long, and comply with RFC1035.
     selfLink: Server defined URL for the resource (output only).
-    snapshotMasterKey: Master key to protect the snapshot. When attempting to
-      use a master key protected snapshot, the key must be provided otherwise
-      the request will fail. Master keys do not protect resource metadata.
+    snapshotMainKey: Main key to protect the snapshot. When attempting to
+      use a main key protected snapshot, the key must be provided otherwise
+      the request will fail. Main keys do not protect resource metadata.
       Format: Random 256-bit key material encoded in base64.
     sourceDisk: The source disk used to create this snapshot.
     sourceDiskId: The 'id' value of the disk used to create this snapshot.
       This value may be used to determine whether the snapshot was taken from
       the current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     status: The status of the persistent disk snapshot (output only).
     storageBytes: A size of the the storage used by the snapshot. As snapshots
@@ -5596,10 +5596,10 @@ class Snapshot(messages.Message):
   licenses = messages.StringField(6, repeated=True)
   name = messages.StringField(7)
   selfLink = messages.StringField(8)
-  snapshotMasterKey = messages.StringField(9)
+  snapshotMainKey = messages.StringField(9)
   sourceDisk = messages.StringField(10)
   sourceDiskId = messages.StringField(11)
-  sourceDiskMasterKey = messages.StringField(12)
+  sourceDiskMainKey = messages.StringField(12)
   status = messages.EnumField('StatusValueValuesEnum', 13)
   storageBytes = messages.IntegerField(14)
   storageBytesStatus = messages.EnumField('StorageBytesStatusValueValuesEnum', 15)

--- a/google-cloud-sdk/lib/googlecloudapis/compute/beta/compute_beta_messages.py
+++ b/google-cloud-sdk/lib/googlecloudapis/compute/beta/compute_beta_messages.py
@@ -283,10 +283,10 @@ class AttachedDisk(messages.Message):
       disk, in the form persistent-disks-x, where x is a number assigned by
       Google Compute Engine. This field is only applicable for persistent
       disks.
-    diskMasterKey: Master key of the disk; required only if the disk already
-      exists and is master key protected. If the disk is being created and a
-      master key is provided, the newly created disk will be protected with
-      this master key. Format: Random 256-bit key material encoded in base64.
+    diskMainKey: Main key of the disk; required only if the disk already
+      exists and is main key protected. If the disk is being created and a
+      main key is provided, the newly created disk will be protected with
+      this main key. Format: Random 256-bit key material encoded in base64.
     index: Assigns a zero-based index to this disk, where 0 is reserved for
       the boot disk. For example, if you have many disks attached to an
       instance, each disk would have a unique index number. If not specified,
@@ -344,7 +344,7 @@ class AttachedDisk(messages.Message):
   autoDelete = messages.BooleanField(1)
   boot = messages.BooleanField(2)
   deviceName = messages.StringField(3)
-  diskMasterKey = messages.StringField(4)
+  diskMainKey = messages.StringField(4)
   index = messages.IntegerField(5, variant=messages.Variant.INT32)
   initializeParams = messages.MessageField('AttachedDiskInitializeParams', 6)
   interface = messages.EnumField('InterfaceValueValuesEnum', 7)
@@ -393,8 +393,8 @@ class AttachedDiskInitializeParams(messages.Message):
       to include the project in the URL:  projects/debian-
       cloud/global/images/debian-7-wheezy-vYYYYMMDD   where vYYYYMMDD is the
       image version. The fully-qualified URL will also work in both cases.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
   """
 
@@ -416,7 +416,7 @@ class AttachedDiskInitializeParams(messages.Message):
   diskStorageType = messages.EnumField('DiskStorageTypeValueValuesEnum', 3)
   diskType = messages.StringField(4)
   sourceImage = messages.StringField(5)
-  sourceImageMasterKey = messages.StringField(6)
+  sourceImageMainKey = messages.StringField(6)
 
 
 class Backend(messages.Message):
@@ -3030,9 +3030,9 @@ class Disk(messages.Message):
       only).
     description: An optional textual description of the resource; provided by
       the client when the resource is created.
-    diskMasterKey: Master key to protect the disk. When attempting to use a
-      master key protected disk, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    diskMainKey: Main key to protect the disk. When attempting to use a
+      main key protected disk, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     id: Unique identifier for the resource; defined by the server (output
       only).
@@ -3049,15 +3049,15 @@ class Disk(messages.Message):
     sourceImageId: The 'id' value of the image used to create this disk. This
       value may be used to determine whether the disk was created from the
       current or a previous instance of a given image.
-    sourceImageMasterKey: Master key of the source image; required only if the
-      source image is master key protected. Format: Random 256-bit key
+    sourceImageMainKey: Main key of the source image; required only if the
+      source image is main key protected. Format: Random 256-bit key
       material encoded in base64.
     sourceSnapshot: The source snapshot used to create this disk.
     sourceSnapshotId: The 'id' value of the snapshot used to create this disk.
       This value may be used to determine whether the disk was created from
       the current or a previous instance of a given disk snapshot.
-    sourceSnapshotMasterKey: Master key of the source snapshot; required only
-      if the source snapshot is master key protected. Format: Random 256-bit
+    sourceSnapshotMainKey: Main key of the source snapshot; required only
+      if the source snapshot is main key protected. Format: Random 256-bit
       key material encoded in base64.
     status: The status of disk creation (output only).
     storageType: DEPRECATED. Storage type of the persistent disk.
@@ -3092,7 +3092,7 @@ class Disk(messages.Message):
 
   creationTimestamp = messages.StringField(1)
   description = messages.StringField(2)
-  diskMasterKey = messages.StringField(3)
+  diskMainKey = messages.StringField(3)
   id = messages.IntegerField(4, variant=messages.Variant.UINT64)
   kind = messages.StringField(5, default=u'compute#disk')
   licenses = messages.StringField(6, repeated=True)
@@ -3102,10 +3102,10 @@ class Disk(messages.Message):
   sizeGb = messages.IntegerField(10)
   sourceImage = messages.StringField(11)
   sourceImageId = messages.StringField(12)
-  sourceImageMasterKey = messages.StringField(13)
+  sourceImageMainKey = messages.StringField(13)
   sourceSnapshot = messages.StringField(14)
   sourceSnapshotId = messages.StringField(15)
-  sourceSnapshotMasterKey = messages.StringField(16)
+  sourceSnapshotMainKey = messages.StringField(16)
   status = messages.EnumField('StatusValueValuesEnum', 17)
   storageType = messages.EnumField('StorageTypeValueValuesEnum', 18)
   type = messages.StringField(19)
@@ -3963,9 +3963,9 @@ class Image(messages.Message):
     diskSizeGb: Size of the image when restored onto a disk (in GiB).
     id: Unique identifier for the resource; defined by the server (output
       only).
-    imageMasterKey: Master key to protect the image. When attempting to use a
-      master key protected image, the key must be provided otherwise the
-      request will fail. Master keys do not protect resource metadata. Format:
+    imageMainKey: Main key to protect the image. When attempting to use a
+      main key protected image, the key must be provided otherwise the
+      request will fail. Main keys do not protect resource metadata. Format:
       Random 256-bit key material encoded in base64.
     kind: Type of the resource.
     licenses: Public visible licenses.
@@ -3977,8 +3977,8 @@ class Image(messages.Message):
     sourceDiskId: The 'id' value of the disk used to create this image. This
       value may be used to determine whether the image was taken from the
       current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     sourceType: Must be "RAW"; provided by the client when the disk image is
       created.
@@ -4055,7 +4055,7 @@ class Image(messages.Message):
   description = messages.StringField(4)
   diskSizeGb = messages.IntegerField(5)
   id = messages.IntegerField(6, variant=messages.Variant.UINT64)
-  imageMasterKey = messages.StringField(7)
+  imageMainKey = messages.StringField(7)
   kind = messages.StringField(8, default=u'compute#image')
   licenses = messages.StringField(9, repeated=True)
   name = messages.StringField(10)
@@ -4063,7 +4063,7 @@ class Image(messages.Message):
   selfLink = messages.StringField(12)
   sourceDisk = messages.StringField(13)
   sourceDiskId = messages.StringField(14)
-  sourceDiskMasterKey = messages.StringField(15)
+  sourceDiskMainKey = messages.StringField(15)
   sourceType = messages.EnumField('SourceTypeValueValuesEnum', 16, default=u'RAW')
   status = messages.EnumField('StatusValueValuesEnum', 17)
 
@@ -5541,16 +5541,16 @@ class Snapshot(messages.Message):
     name: Name of the resource; provided by the client when the resource is
       created. The name must be 1-63 characters long, and comply with RFC1035.
     selfLink: Server defined URL for the resource (output only).
-    snapshotMasterKey: Master key to protect the snapshot. When attempting to
-      use a master key protected snapshot, the key must be provided otherwise
-      the request will fail. Master keys do not protect resource metadata.
+    snapshotMainKey: Main key to protect the snapshot. When attempting to
+      use a main key protected snapshot, the key must be provided otherwise
+      the request will fail. Main keys do not protect resource metadata.
       Format: Random 256-bit key material encoded in base64.
     sourceDisk: The source disk used to create this snapshot.
     sourceDiskId: The 'id' value of the disk used to create this snapshot.
       This value may be used to determine whether the snapshot was taken from
       the current or a previous instance of a given disk name.
-    sourceDiskMasterKey: Master key of the source disk; required only if the
-      source disk is master key protected. Format: Random 256-bit key material
+    sourceDiskMainKey: Main key of the source disk; required only if the
+      source disk is main key protected. Format: Random 256-bit key material
       encoded in base64.
     status: The status of the persistent disk snapshot (output only).
     storageBytes: A size of the the storage used by the snapshot. As snapshots
@@ -5596,10 +5596,10 @@ class Snapshot(messages.Message):
   licenses = messages.StringField(6, repeated=True)
   name = messages.StringField(7)
   selfLink = messages.StringField(8)
-  snapshotMasterKey = messages.StringField(9)
+  snapshotMainKey = messages.StringField(9)
   sourceDisk = messages.StringField(10)
   sourceDiskId = messages.StringField(11)
-  sourceDiskMasterKey = messages.StringField(12)
+  sourceDiskMainKey = messages.StringField(12)
   status = messages.EnumField('StatusValueValuesEnum', 13)
   storageBytes = messages.IntegerField(14)
   storageBytesStatus = messages.EnumField('StorageBytesStatusValueValuesEnum', 15)

--- a/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
+++ b/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_client.py
@@ -178,11 +178,11 @@ class ContainerV1beta1(base_api.BaseApiClient):
           }
 
     def Create(self, request, global_params=None):
-      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes master instance.
+      """Creates a cluster, consisting of the specified number and type of Google Compute Engine instances, plus a Kubernetes main instance.
 
 The cluster is created in the project's default network.
 
-A firewall is added that allows traffic into port 443 on the master, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
+A firewall is added that allows traffic into port 443 on the main, which enables HTTPS. A firewall and a route is added for each node to allow the containers on that node to communicate with all other instances in the cluster.
 
 Finally, a route named k8s-iproute-10-xx-0-0 is created to track that the cluster's 10.xx.0.0/16 CIDR has been assigned.
 
@@ -197,7 +197,7 @@ Finally, a route named k8s-iproute-10-xx-0-0 is created to track that the cluste
           config, request, global_params=global_params)
 
     def Delete(self, request, global_params=None):
-      """Deletes the cluster, including the Kubernetes master and all worker nodes.
+      """Deletes the cluster, including the Kubernetes main and all worker nodes.
 
 Firewalls and routes that were configured at cluster creation are also deleted.
 

--- a/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
+++ b/google-cloud-sdk/lib/googlecloudapis/container/v1beta1/container_v1beta1_messages.py
@@ -18,7 +18,7 @@ class Cluster(messages.Message):
     StatusValueValuesEnum: [Output only] The current status of this cluster.
 
   Fields:
-    clusterApiVersion: The API version of the Kubernetes master and kubelets
+    clusterApiVersion: The API version of the Kubernetes main and kubelets
       running in this cluster. Leave blank to pick up the latest stable
       release, or specify a version of the form "x.y.z". The Google Container
       Engine release notes lists the currently supported versions. If an
@@ -30,11 +30,11 @@ class Cluster(messages.Message):
       RFC3339 text format.
     description: An optional description of this cluster.
     endpoint: [Output only] The IP address of this cluster's Kubernetes
-      master. The endpoint can be accessed from the internet at
-      https://username:password@endpoint/.  See the masterAuth property of
+      main. The endpoint can be accessed from the internet at
+      https://username:password@endpoint/.  See the mainAuth property of
       this resource for username and password information.
-    masterAuth: The HTTP basic authentication information for accessing the
-      master. Because the master endpoint is open to the internet, you should
+    mainAuth: The HTTP basic authentication information for accessing the
+      main. Because the main endpoint is open to the internet, you should
       create a strong password.
     name: The name of this cluster. The name must be unique within this
       project and zone, and can be up to 40 characters with the following
@@ -48,7 +48,7 @@ class Cluster(messages.Message):
       node for hosting containers.
     numNodes: The number of nodes to create in this cluster. You must ensure
       that your Compute Engine resource quota is sufficient for this number of
-      instances plus one (to include the master). You must also have available
+      instances plus one (to include the main). You must also have available
       firewall and routes quota.
     selfLink: [Output only] Server-defined URL for the resource.
     servicesIpv4Cidr: [Output only] The IP addresses of the Kubernetes
@@ -80,7 +80,7 @@ class Cluster(messages.Message):
   creationTimestamp = messages.StringField(3)
   description = messages.StringField(4)
   endpoint = messages.StringField(5)
-  masterAuth = messages.MessageField('MasterAuth', 6)
+  mainAuth = messages.MessageField('MainAuth', 6)
   name = messages.StringField(7)
   network = messages.StringField(8)
   nodeConfig = messages.MessageField('NodeConfig', 9)
@@ -251,13 +251,13 @@ class ListOperationsResponse(messages.Message):
   operations = messages.MessageField('Operation', 1, repeated=True)
 
 
-class MasterAuth(messages.Message):
-  """A MasterAuth object.
+class MainAuth(messages.Message):
+  """A MainAuth object.
 
   Fields:
-    password: The password to use when accessing the Kubernetes master
+    password: The password to use when accessing the Kubernetes main
       endpoint.
-    user: The username to use when accessing the Kubernetes master endpoint.
+    user: The username to use when accessing the Kubernetes main endpoint.
   """
 
   password = messages.StringField(1)

--- a/google-cloud-sdk/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
+++ b/google-cloud-sdk/lib/googlecloudapis/sqladmin/v1beta3/sqladmin_v1beta3_messages.py
@@ -160,7 +160,7 @@ class DatabaseInstance(messages.Message):
     ipAddresses: The assigned IP addresses for the instance.
     ipv6Address: The IPv6 address assigned to the instance.
     kind: This is always sql#instance.
-    masterInstanceName: The name of the instance which will act as master in
+    mainInstanceName: The name of the instance which will act as main in
       the replication setup.
     maxDiskSize: The maximum disk size of the instance in bytes.
     project: The project ID of the project containing the Cloud SQL instance.
@@ -189,7 +189,7 @@ class DatabaseInstance(messages.Message):
   ipAddresses = messages.MessageField('IpMapping', 6, repeated=True)
   ipv6Address = messages.StringField(7)
   kind = messages.StringField(8, default=u'sql#instance')
-  masterInstanceName = messages.StringField(9)
+  mainInstanceName = messages.StringField(9)
   maxDiskSize = messages.IntegerField(10)
   project = messages.StringField(11)
   region = messages.StringField(12)

--- a/google-cloud-sdk/lib/googlecloudsdk/compute/lib/master_key_utils.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/compute/lib/master_key_utils.py
@@ -1,5 +1,5 @@
 # Copyright 2014 Google Inc. All Rights Reserved.
-"""Utility functions for managing customer supplied master keys."""
+"""Utility functions for managing customer supplied main keys."""
 
 import argparse
 import base64
@@ -15,10 +15,10 @@ BASE64_KEY_LENGTH_IN_CHARS = 44
 SUPPRESS_MASTER_KEY_UTILS = True
 
 
-class MissingMasterKeyException(exceptions.ToolException):
+class MissingMainKeyException(exceptions.ToolException):
 
   def __init__(self, resource):
-    super(MissingMasterKeyException, self).__init__(
+    super(MissingMainKeyException, self).__init__(
         'Key required for resource [{}], but none found.'.format(resource))
 
 
@@ -63,32 +63,32 @@ def ValidateKey(base64_encoded_string):
             len(base64_encoded_string)))
 
 
-def AddMasterKeyArgs(parser, flags_about_creation=True):
-  """Adds arguments related to master keys."""
+def AddMainKeyArgs(parser, flags_about_creation=True):
+  """Adds arguments related to main keys."""
 
-  master_key_file = parser.add_argument(
-      '--master-key-file',
+  main_key_file = parser.add_argument(
+      '--main-key-file',
       help=(argparse.SUPPRESS if SUPPRESS_MASTER_KEY_UTILS
-            else 'Path to a master key file'),
+            else 'Path to a main key file'),
       metavar='FILE')
-  master_key_file.detailed_help = (
-      'Path to a master key file, mapping GCE resources to user managed '
+  main_key_file.detailed_help = (
+      'Path to a main key file, mapping GCE resources to user managed '
       'keys to be used when creating, mounting, or snapshotting disks. ')
   # TODO(user)
   # Argument - indicates the key file should be read from stdin.'
 
   if flags_about_creation:
-    no_require_master_key_create = parser.add_argument(
-        '--no-require-master-key-create',
+    no_require_main_key_create = parser.add_argument(
+        '--no-require-main-key-create',
         help=(argparse.SUPPRESS if SUPPRESS_MASTER_KEY_UTILS
-              else 'Allow creating of resources not protected by master key.'),
+              else 'Allow creating of resources not protected by main key.'),
         action='store_true')
-    no_require_master_key_create.detailed_help = (
-        'When invoked with --master-key-file gcloud will refuse to create '
+    no_require_main_key_create.detailed_help = (
+        'When invoked with --main-key-file gcloud will refuse to create '
         'resources not protected by a user managed key in the key file.  This '
         'is intended to prevent incorrect gcloud invocations from accidentally '
         'creating resources with no user managed key.  This flag disables the '
-        'check and allows creation of resources without master keys.')
+        'check and allows creation of resources without main keys.')
 
 
 class UriPattern(object):
@@ -107,7 +107,7 @@ class UriPattern(object):
     return 'Uri Pattern: ' + self._path_as_string
 
 
-class MasterKeyStore(object):
+class MainKeyStore(object):
   """Represents a map from resource patterns to keys."""
 
   # Members
@@ -115,7 +115,7 @@ class MasterKeyStore(object):
 
   @staticmethod
   def FromFile(fname):
-    """FromFile loads a MasterKeyStore from a file.
+    """FromFile loads a MainKeyStore from a file.
 
     Args:
       fname: str, the name of a file intended to contain a well-formed key file
@@ -132,34 +132,34 @@ class MasterKeyStore(object):
     with open(fname) as infile:
       content = infile.read()
 
-    return MasterKeyStore(content)
+    return MainKeyStore(content)
 
   @staticmethod
   def FromArgs(args):
-    """FromFile attempts to load a MasterKeyStore from a command's args.
+    """FromFile attempts to load a MainKeyStore from a command's args.
 
     Args:
-      args: CLI args with a master_key_file field set
+      args: CLI args with a main_key_file field set
 
     Returns:
-      A MasterKeyStore, if a valid key file name is provided as master_key_file
-      None, if args.master_key_file is None
+      A MainKeyStore, if a valid key file name is provided as main_key_file
+      None, if args.main_key_file is None
 
     Raises:
       exceptions.BadFileException: there's a problem reading fname
       exceptions.InvalidKeyFileException: the key file failed to parse
         or was otherwise invalid
     """
-    assert hasattr(args, 'master_key_file')
+    assert hasattr(args, 'main_key_file')
 
-    if args.master_key_file is None:
+    if args.main_key_file is None:
       return None
 
-    return MasterKeyStore.FromFile(args.master_key_file)
+    return MainKeyStore.FromFile(args.main_key_file)
 
   @staticmethod
   def _ParseAndValidate(s):
-    """_ParseAndValidate(s) inteprets s as a master key file.
+    """_ParseAndValidate(s) inteprets s as a main key file.
 
     Args:
       s: str, an input to parse
@@ -220,7 +220,7 @@ class MasterKeyStore(object):
 
     Raises:
       InvalidKeyFileException: if there are two records matching the resource.
-      MissingMasterKeyException: if raise_if_missing and no key is found
+      MissingMainKeyException: if raise_if_missing and no key is found
         for the provided resoure.
     """
 
@@ -240,26 +240,26 @@ class MasterKeyStore(object):
         search_state = (pat, key)
 
     if raise_if_missing and (search_state[1] is None):
-      raise MissingMasterKeyException(resource)
+      raise MissingMainKeyException(resource)
 
     return search_state[1]
 
   def __init__(self, json_string):
-    self.state = MasterKeyStore._ParseAndValidate(json_string)
+    self.state = MainKeyStore._ParseAndValidate(json_string)
 
 
-def MaybeLookupKey(master_keys_or_none, resource):
-  if master_keys_or_none and resource:
-    return master_keys_or_none.LookupKey(resource)
+def MaybeLookupKey(main_keys_or_none, resource):
+  if main_keys_or_none and resource:
+    return main_keys_or_none.LookupKey(resource)
 
   return None
 
 
-def MaybeLookupKeys(master_keys_or_none, resources):
-  return [MaybeLookupKey(master_keys_or_none, r) for r in resources]
+def MaybeLookupKeys(main_keys_or_none, resources):
+  return [MaybeLookupKey(main_keys_or_none, r) for r in resources]
 
 
-def MaybeLookupKeysByUri(master_keys_or_none, parser, uris):
+def MaybeLookupKeysByUri(main_keys_or_none, parser, uris):
   return MaybeLookupKeys(
-      master_keys_or_none,
+      main_keys_or_none,
       [(parser.Parse(u) if u else None) for u in uris])

--- a/google-cloud-sdk/lib/googlecloudsdk/compute/subcommands/disks/create.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/compute/subcommands/disks/create.py
@@ -4,7 +4,7 @@ from googlecloudsdk.calliope import arg_parsers
 from googlecloudsdk.compute.lib import base_classes
 from googlecloudsdk.compute.lib import constants
 from googlecloudsdk.compute.lib import image_utils
-from googlecloudsdk.compute.lib import master_key_utils
+from googlecloudsdk.compute.lib import main_key_utils
 from googlecloudsdk.compute.lib import utils
 from googlecloudsdk.compute.lib import zone_utils
 
@@ -42,7 +42,7 @@ class Create(base_classes.BaseAsyncCreator, image_utils.ImageExpander,
 
     source_group = parser.add_mutually_exclusive_group()
 
-    master_key_utils.AddMasterKeyArgs(parser)
+    main_key_utils.AddMainKeyArgs(parser)
 
     def AddImageHelp():
       return """\
@@ -138,11 +138,11 @@ class Create(base_classes.BaseAsyncCreator, image_utils.ImageExpander,
     else:
       snapshot_uri = None
 
-    master_keys = master_key_utils.MasterKeyStore.FromArgs(args)
+    main_keys = main_key_utils.MainKeyStore.FromArgs(args)
 
     image_key_or_none, snapshot_key_or_none = (
-        master_key_utils.MaybeLookupKeysByUri(
-            master_keys, self.resources, [source_image_uri, snapshot_uri]))
+        main_key_utils.MaybeLookupKeysByUri(
+            main_keys, self.resources, [source_image_uri, snapshot_uri]))
 
     for disk_ref in disk_refs:
       if args.type:
@@ -153,12 +153,12 @@ class Create(base_classes.BaseAsyncCreator, image_utils.ImageExpander,
       else:
         type_uri = None
 
-      if master_keys:
-        disk_key_or_none = master_keys.LookupKey(
-            disk_ref, not args.no_require_master_key_create)
-        kwargs = {'diskMasterKey': disk_key_or_none,
-                  'sourceImageMasterKey': image_key_or_none,
-                  'sourceSnapshotMasterKey': snapshot_key_or_none}
+      if main_keys:
+        disk_key_or_none = main_keys.LookupKey(
+            disk_ref, not args.no_require_main_key_create)
+        kwargs = {'diskMainKey': disk_key_or_none,
+                  'sourceImageMainKey': image_key_or_none,
+                  'sourceSnapshotMainKey': snapshot_key_or_none}
       else:
         kwargs = {}
 

--- a/google-cloud-sdk/lib/googlecloudsdk/compute/subcommands/instances/attach_disk.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/compute/subcommands/instances/attach_disk.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Google Inc. All Rights Reserved.
 """Command for attaching a disk to an instance."""
 from googlecloudsdk.compute.lib import base_classes
-from googlecloudsdk.compute.lib import master_key_utils
+from googlecloudsdk.compute.lib import main_key_utils
 from googlecloudsdk.compute.lib import utils
 
 MODE_OPTIONS = ['ro', 'rw']
@@ -44,7 +44,7 @@ class AttachDisk(base_classes.NoOutputAsyncMutator):
         resource_type='instance',
         operation_type='attach a disk to')
 
-    master_key_utils.AddMasterKeyArgs(parser, flags_about_creation=False)
+    main_key_utils.AddMainKeyArgs(parser, flags_about_creation=False)
 
   @property
   def service(self):
@@ -69,11 +69,11 @@ class AttachDisk(base_classes.NoOutputAsyncMutator):
     else:
       mode = self.messages.AttachedDisk.ModeValueValuesEnum.READ_ONLY
 
-    master_keys = master_key_utils.MasterKeyStore.FromArgs(args)
+    main_keys = main_key_utils.MainKeyStore.FromArgs(args)
 
-    if master_keys:
-      disk_key_or_none = master_keys.LookupKey(disk_ref)
-      kwargs = {'diskMasterKey': disk_key_or_none}
+    if main_keys:
+      disk_key_or_none = main_keys.LookupKey(disk_ref)
+      kwargs = {'diskMainKey': disk_key_or_none}
     else:
       kwargs = {}
 

--- a/google-cloud-sdk/lib/googlecloudsdk/dns/lib/import_util.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/dns/lib/import_util.py
@@ -50,7 +50,7 @@ def _SOATranslation(rdata, origin):
 
   Returns:
     str, The translation of the given SOA rdata which includes all the required
-    SOA fields. Note that the master NS name is left in a substitutable form
+    SOA fields. Note that the main NS name is left in a substitutable form
     because it is always provided by Cloud DNS.
   """
   return ' '.join(
@@ -184,7 +184,7 @@ def RecordSetsFromZoneFile(zone_file, domain):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     zone file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   zone_contents = zone.from_file(zone_file, domain, check_origin=False)
@@ -206,7 +206,7 @@ def RecordSetsFromYamlFile(yaml_file):
     A (name, type) keyed dict of ResourceRecordSets that were obtained from the
     yaml file. Note that only A, AAAA, CNAME, MX, PTR, SOA, SPF, SRV, and TXT
     record-sets are retrieved. Other record-set types are not supported by Cloud
-    DNS. Also, the master NS field for SOA records is discarded since that is
+    DNS. Also, the main NS field for SOA records is discarded since that is
     provided by Cloud DNS.
   """
   record_sets = {}
@@ -226,7 +226,7 @@ def RecordSetsFromYamlFile(yaml_file):
     record_set.rrdatas = yaml_record_set['rrdatas']
 
     if rdata_type is rdatatype.SOA:
-      # Make master NS name substitutable.
+      # Make main NS name substitutable.
       rdata_parts = record_set.rrdatas[0].split()
       rdata_parts[0] = '{0}'
       record_set.rrdatas[0] = ' '.join(rdata_parts)
@@ -255,14 +255,14 @@ def _RecordSetCopy(record_set):
 
 
 def _SOAReplacement(current_record, record_to_be_imported):
-  """Returns the replacement SOA record with restored master NS name.
+  """Returns the replacement SOA record with restored main NS name.
 
   Args:
     current_record: ResourceRecordSet, Current record-set.
     record_to_be_imported: ResourceRecordSet, Record-set to be imported.
 
   Returns:
-    ResourceRecordSet, the replacement SOA record with restored master NS name.
+    ResourceRecordSet, the replacement SOA record with restored main NS name.
   """
   replacement = _RecordSetCopy(record_to_be_imported)
   replacement.rrdatas[0] = replacement.rrdatas[0].format(

--- a/google-cloud-sdk/lib/googlecloudsdk/gcloud/sdktools/root/init.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/gcloud/sdktools/root/init.py
@@ -47,7 +47,7 @@ class Init(base.Command):
           git repository associated with PROJECT. This repository will
           automatically be connected to Google, and it will use the credentials
           indicated as _active_ by `gcloud auth list`. Pushing
-          to the origin's _master_ branch will trigger an App Engine deployment
+          to the origin's _main_ branch will trigger an App Engine deployment
           using the contents of that branch.
       """.format(dotgcloud=config.Paths.CLOUDSDK_WORKSPACE_CONFIG_DIR_NAME),
       'EXAMPLES': textwrap.dedent("""\
@@ -60,7 +60,7 @@ class Init(base.Command):
             $ cd MYPROJECT/default
             $ git pull
               https://github.com/GoogleCloudPlatform/appengine-helloworld-python
-            $ git push origin master
+            $ git push origin main
       """),
   }
 

--- a/google-cloud-sdk/lib/googlecloudsdk/sql/tools/instances/create.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/sql/tools/instances/create.py
@@ -94,11 +94,11 @@ class Create(base.Command):
         'instance',
         help='Cloud SQL instance ID.')
     parser.add_argument(
-        '--master-instance-name',
+        '--main-instance-name',
         required=False,
-        help='Name of the instance which will act as master in the replication '
+        help='Name of the instance which will act as main in the replication '
         'setup. The newly created instance will be a read replica of the '
-        'specified master instance.')
+        'specified main instance.')
     parser.add_argument(
         '--pricing-plan',
         '-p',
@@ -176,7 +176,7 @@ class Create(base.Command):
 
     instance_resource = util.ConstructInstanceFromArgs(sql_messages, args)
 
-    if args.master_instance_name:
+    if args.main_instance_name:
       replication = 'ASYNCHRONOUS'
       activation_policy = 'ALWAYS'
     else:

--- a/google-cloud-sdk/lib/googlecloudsdk/sql/util.py
+++ b/google-cloud-sdk/lib/googlecloudsdk/sql/util.py
@@ -274,7 +274,7 @@ def ConstructInstanceFromArgs(sql_messages, args, original=None):
   instance_resource = sql_messages.DatabaseInstance(
       region=region,
       databaseVersion=database_version,
-      masterInstanceName=getattr(args, 'master_instance_name', None),
+      mainInstanceName=getattr(args, 'main_instance_name', None),
       settings=settings)
 
   return instance_resource

--- a/google-cloud-sdk/lib/jinja2/pkg_resources.py
+++ b/google-cloud-sdk/lib/jinja2/pkg_resources.py
@@ -2693,7 +2693,7 @@ def _initialize(g):
             g[name] = getattr(_manager, name)
 _initialize(globals())
 
-# Prepare the master working set and make the ``require()`` API available
+# Prepare the main working set and make the ``require()`` API available
 _declare_state('object', working_set = WorkingSet())
 
 try:

--- a/google-cloud-sdk/platform/gcutil/lib/google_compute_engine/gcutil_lib/command_base.py
+++ b/google-cloud-sdk/platform/gcutil/lib/google_compute_engine/gcutil_lib/command_base.py
@@ -2499,13 +2499,13 @@ class GoogleComputeListCommand(GoogleComputeCommand):
                              region=region))
     return results
 
-  def _GetDesiredColumnsAndSpecs(self, default_print_spec, master_print_spec):
+  def _GetDesiredColumnsAndSpecs(self, default_print_spec, main_print_spec):
     """Get the print specs for this operation given the specified flags.
 
     Args:
       default_print_spec: The default print spec to use, if the flag is
         unspecified.
-      master_print_spec: A list of all possible columns and associated fields.
+      main_print_spec: A list of all possible columns and associated fields.
 
     Returns:
       A tuple (column_names, print_specs), corresponding to column names and
@@ -2515,22 +2515,22 @@ class GoogleComputeListCommand(GoogleComputeCommand):
       UsageError: Invalid field given.
     """
     if self._flags.columns and 'all' in self._flags.columns:
-      column_names = [x[0] for x in master_print_spec]
+      column_names = [x[0] for x in main_print_spec]
     elif self._flags.columns:
       column_names = self._flags.columns
     else:
       column_names = [x for x in default_print_spec]
 
-    # Pull the desired print specs out of the master list.
+    # Pull the desired print specs out of the main list.
     desired_specs = []
     for col in column_names:
-      specs = [spec for spec in master_print_spec if spec[0] == col]
+      specs = [spec for spec in main_print_spec if spec[0] == col]
       if specs:
         desired_specs.extend(specs)
       else:
         raise app.UsageError(
             'Invalid field: %s. Valid columns are <%s>.' %
-            (col, '|'.join(spec[0] for spec in master_print_spec)))
+            (col, '|'.join(spec[0] for spec in main_print_spec)))
 
     return column_names, desired_specs
 

--- a/google-cloud-sdk/platform/gcutil/lib/google_compute_engine/gcutil_lib/operation_cmds.py
+++ b/google-cloud-sdk/platform/gcutil/lib/google_compute_engine/gcutil_lib/operation_cmds.py
@@ -86,7 +86,7 @@ class OperationCommand(command_base.GoogleComputeCommand):
       # operation_name is really ambiguous. Get the base name.
       operation = operation_name.split('/')[-1]
 
-      # Search for the item in the master list of all items.
+      # Search for the item in the main list of all items.
       filter_expression = ('name eq %s' % operation)
 
       aggregated_items = utils.AllAggregated(

--- a/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
+++ b/google-cloud-sdk/platform/gsutil/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
+++ b/google-cloud-sdk/platform/gsutil/gslib/commands/notification.py
@@ -126,7 +126,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://developers.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/connection.py
@@ -397,8 +397,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -424,11 +424,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -459,7 +459,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -509,15 +509,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -701,15 +701,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/emr/step.py
@@ -130,7 +130,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/opsworks/layer1.py
@@ -698,8 +698,8 @@ class OpsWorksConnection(AWSQueryConnection):
         + php-app: A PHP App Server layer
         + nodejs-app: A Node.js App Server layer
         + memcached: A Memcached layer
-        + db-master: A MySQL layer
-        + monitoring-master: A Ganglia layer
+        + db-main: A MySQL layer
+        + monitoring-main: A Ganglia layer
         + custom: A custom layer
 
         :type name: string

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/__init__.py
@@ -139,8 +139,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -169,8 +169,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -399,8 +399,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -424,8 +424,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -563,7 +563,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -594,8 +594,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -681,8 +681,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/rds2/layer1.py
@@ -323,8 +323,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -419,9 +419,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -454,8 +454,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -538,7 +538,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -657,8 +657,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2482,7 +2482,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2610,14 +2610,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2628,7 +2628,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2662,7 +2662,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2814,8 +2814,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/boto/redshift/layer1.py
@@ -308,8 +308,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -388,9 +388,9 @@ class RedshiftConnection(AWSQueryConnection):
             the Amazon Redshift Management Guide .
         Valid Values: `dw.hs1.xlarge` | `dw.hs1.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -401,9 +401,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -565,8 +565,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2193,7 +2193,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2203,7 +2203,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying parameter group requires a reboot for parameters to
@@ -2283,15 +2283,15 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of Virtual Private Cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
         Operations never return the password, so this operation provides a way
-            to regain access to the master user account for a cluster if the
+            to regain access to the main user account for a cluster if the
             password is lost.
 
 
@@ -2392,8 +2392,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_connection.py
@@ -175,7 +175,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -231,7 +231,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(response.instancegroups[0].name, "Main instance group")
         self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
         self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
@@ -732,7 +732,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -749,7 +749,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -767,11 +767,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -799,14 +799,14 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -828,7 +828,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -70,8 +70,8 @@ JOB_FLOW_EXAMPLE = """
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -266,8 +266,8 @@ JOB_FLOW_COMPLETED = """
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -285,7 +285,7 @@ JOB_FLOW_COMPLETED = """
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -300,13 +300,13 @@ JOB_FLOW_COMPLETED = """
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -346,8 +346,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -364,8 +364,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
+++ b/google-cloud-sdk/platform/gsutil/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.